### PR TITLE
Add Typescript support

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,38 @@ elt.innerHTML = result.toHTML();
 document.body.append(elt);
 ```
 
+### Typescript
+
+See [index.d.ts](./index.d.ts) for Typescript types for this library.
+
+```typescript
+import { decode } from 'codec-string';
+
+interface CodecDetails {
+    label: string;
+    error?: string;
+    details: string[];
+}
+
+interface CodecInformation {
+    codec: string;
+    error?: string;
+    details: CodecDetails[];
+}
+
+const codec = 'avc1.64002A';
+const { error, decodes } = decode(codec);
+const ci: CodecInformation = {
+  codec,
+  error,
+  details: decodes.map(({parsed, error, label}) => ({
+    label,
+    error,
+    details: parsed.map(p => p.decode),
+  })),
+};
+```
+
 ### CommonJS module in Node.js
 
 ```javascript

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,17 @@
+export interface CodecParserResult {
+    decode: string;
+}
+
+export interface DecodedCodec {
+    parsed: CodecParserResult[] | null;
+    error?: string;
+    label: string;
+}
+
+export interface CodecDecodeResults {
+    decodes: DecodedCodec[];
+    error?: string;
+    toHTML: () => string;
+}
+
+export function decode(val: string): CodecDecodeResults;

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "sideEffects": [
     "./src/decode.js"
   ],
+  "types": "index.d.ts",
   "keywords": [],
   "author": "paul_higgs@hotmail.com",
   "license": "BSD",
@@ -51,5 +52,9 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/paulhiggs/codec-string"
-  }
+  },
+  "files": [
+    "index.d.ts",
+    "dist"
+  ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,10 @@
+{
+    "include": [
+        "index.d.ts"
+    ],
+    "compilerOptions": {
+        "noImplicitAny": true,
+        "strict": true,
+        "skipLibCheck": false
+    }
+}

--- a/webpack-esm.cjs
+++ b/webpack-esm.cjs
@@ -1,6 +1,6 @@
 const path = require('path');
-
 const { merge } = require('webpack-merge');
+const CopyPlugin = require('copy-webpack-plugin');
 
 const common = require('./webpack.common.cjs');
 
@@ -19,6 +19,15 @@ module.exports = merge(
 			module: true,
 			path: path.resolve(__dirname, 'dist/esm'),
 		},
+		plugins: [
+			new CopyPlugin({
+				patterns: [
+					{
+						from: 'index.d.ts',
+					},
+				],
+			}),
+		],
 		experiments: {
 			outputModule: true,
 		},


### PR DESCRIPTION
To allow the ESM build to be more easily used in Typescript applications, provide type hints for the main decode() function.
